### PR TITLE
Edited the remarks for RDFstar-demo.md 

### DIFF
--- a/RDFstar-demo.md
+++ b/RDFstar-demo.md
@@ -27,7 +27,7 @@ Below some examples of how to model complex relationships in RDF
 ```
 @prefix : <http://www.example.org/> .
 :statementId#1 { :bob :hasSpouse :alice }
-{ :statementId#1 :startDate "2020-02-11"^^xsd:date :metadata . }
+:statementId#1 :startDate "2020-02-11"^^xsd:date .
 ```
 
 #### 4. RDF-star


### PR DESCRIPTION
* Changed to 'RDF-star' from 'RDF*'.  Idem for 'SPARQL-star' vs 'SPARQL*'

* Changed "complex relationships" from "complex concepts"

* Renamed: man and :woman to :alice and :bob

* In 'N-ary relations' example: used lowercase for the instance :Marriage1

* Changed the 'Named Graphs' example to TriG

* Changed 'Expressing data certainty' as suggested to a certainty of 0.4 so that the triple is not asserted

* Did not change the following "'Expressing data value qualifiers': I am not a big fan of using RDF-star for expressing units. For this kind of use-case, I much prefer using a dedicated datatype (e.g. cdt:ucum), an intermediary node ([ rdf:value 32.1; :unit "cm" ]) or a dedicated property (:heightInCm 32.1)." @kmitd

* Added a longer, educational section about modelling for 'Expressing data value qualifiers' and 'Expressing data provenance'

* Altered and explained the SPARQL-bind example

* 'Coverting' → 'Converting'